### PR TITLE
Add support for more buttons with HDMI-CEC

### DIFF
--- a/src/main/java/com/archos/mediacenter/video/player/PlayerController.java
+++ b/src/main/java/com/archos/mediacenter/video/player/PlayerController.java
@@ -2052,20 +2052,24 @@ public class PlayerController implements View.OnTouchListener, OnGenericMotionLi
                             if (DBG) Log.d(TAG, "onKey, button up");
                             return true;
                         case KeyEvent.KEYCODE_O:
+                        case KeyEvent.KEYCODE_PROG_RED:
                             if (isShowing())
                                 hide();
                             else
                                 show(FLAG_SIDE_ALL_EXCEPT_UNLOCK_INSTRUCTIONS, 0);
                             return true;
                         case KeyEvent.KEYCODE_F:
+                        case KeyEvent.KEYCODE_PROG_GREEN:
                             mSurfaceController.switchVideoFormat();
                             return true;
                         case KeyEvent.KEYCODE_J:
                         case KeyEvent.KEYCODE_S:
+                        case KeyEvent.KEYCODE_PROG_YELLOW:
                             mSettings.switchSubtitleTrack();
                             return true;
                         case KeyEvent.KEYCODE_POUND:
                         case KeyEvent.KEYCODE_A:
+                        case KeyEvent.KEYCODE_PROG_BLUE:
                             mSettings.switchAudioTrack();
                             return true;
                     }


### PR DESCRIPTION
When using the HDMI-CEC buttons, you have access to the COLOURED BUTTONS (Red, Green, Yellow, Blue). So map them to useful actions.