### PR TITLE
Fix the zh-cn localization for Nseasons

### DIFF
--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -269,7 +269,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> 集</item>
     </plurals>
     <plurals name="Nseasons">
-        <item quantity="other">第 <xliff:g id="count">%d</xliff:g> 季</item>
+        <item quantity="other"><xliff:g id="count">%d</xliff:g> 季</item>
     </plurals>
     <!-- Media Center -->
     <string name="mediacenterlabel">媒体中心</string>


### PR DESCRIPTION
"N seasons" should be translated to "N 季" instead of "第 N 季". "第 N 季" means "Season N", not "N seasons".