### PR TITLE
Foreground service for external player playback

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1154,6 +1154,11 @@
         <service android:name="com.archos.mediacenter.video.player.PlayerService"
             android:exported="true" android:foregroundServiceType="mediaPlayback"/>
 
+        <service
+            android:name=".player.ExternalPlayerService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
+
         <service android:name="com.archos.mediascraper.AutoScrapeService"/>
         <service android:name="com.archos.mediascraper.AllCollectionScrapeService"/>
         <service android:name="com.archos.mediacenter.video.browser.FileManagerService"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1032,4 +1032,8 @@
     <string name="networks">Networks:</string>
     <string name="premiered">Premiered:</string>
 
+    <string name="external_player_service_title">External player playback</string>
+    <string name="external_player_service_description">Nova Video Player provides content for an external player</string>
+    <string name="stop">Stop</string>
+
 </resources>

--- a/src/main/java/com/archos/mediacenter/video/player/ExternalPlayerService.java
+++ b/src/main/java/com/archos/mediacenter/video/player/ExternalPlayerService.java
@@ -1,0 +1,136 @@
+package com.archos.mediacenter.video.player;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
+
+import com.archos.mediacenter.video.R;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExternalPlayerService extends Service {
+
+    private static final String ACTION_STOP_SERVICE = "StopExternalPlayerService";
+
+    private static final String NOTIFICATION_CHANNEL_ID = "ExternalPlayerService";
+    private static final int NOTIFICATION_ID = 13;
+
+    private static final Logger log = LoggerFactory.getLogger(ExternalPlayerService.class);
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        log.debug("onCreate()");
+
+        IntentFilter intentFilter = new IntentFilter(ACTION_STOP_SERVICE);
+        registerReceiver(stopServiceBroadcastReceiver, intentFilter, Context.RECEIVER_NOT_EXPORTED);
+
+        startForeground(NOTIFICATION_ID, createNotification());
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        log.debug("onStartCommand({})", intent);
+        return START_NOT_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        log.debug("onDestroy()");
+        unregisterReceiver(stopServiceBroadcastReceiver);
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private Notification createNotification() {
+        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        createNotificationChannel(notificationManager);
+
+        return new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                .setSmallIcon(R.drawable.nova_notification)
+                .setContentTitle(getString(R.string.external_player_service_title))
+                .setContentText(getString(R.string.external_player_service_description))
+                .setWhen(0)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .addAction(0, getString(R.string.stop), createStopServicePendingIntent())
+                .build();
+    }
+
+    private void createNotificationChannel(NotificationManager notificationManager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+
+        NotificationChannel notificationChannel = new NotificationChannel(
+                NOTIFICATION_CHANNEL_ID,
+                getString(R.string.external_player_service_title),
+                NotificationManager.IMPORTANCE_LOW
+        );
+
+        notificationChannel.enableVibration(false);
+        notificationChannel.enableLights(false);
+        notificationChannel.setShowBadge(false);
+
+        notificationManager.createNotificationChannel(notificationChannel);
+    }
+
+    private PendingIntent createStopServicePendingIntent() {
+        Intent intent = new Intent(ACTION_STOP_SERVICE);
+        intent.setPackage(getPackageName());
+
+        return PendingIntent.getBroadcast(
+                this,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+    }
+
+    private static Intent createServiceIntent(Context context) {
+        return new Intent(context, ExternalPlayerService.class);
+    }
+
+    public static void startService(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            final Intent intent = createServiceIntent(context);
+            context.startForegroundService(intent);
+        }
+    }
+
+    public static void stopService(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            final Intent intent = createServiceIntent(context);
+            context.stopService(intent);
+        }
+    }
+
+    private final BroadcastReceiver stopServiceBroadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (ACTION_STOP_SERVICE.equals(intent.getAction())) {
+                stopSelf();
+            }
+        }
+
+    };
+
+}

--- a/src/main/java/com/archos/mediacenter/video/utils/ExternalPlayerResultListener.java
+++ b/src/main/java/com/archos/mediacenter/video/utils/ExternalPlayerResultListener.java
@@ -28,6 +28,7 @@ import com.archos.mediacenter.utils.trakt.TraktService;
 import com.archos.mediacenter.utils.videodb.IndexHelper;
 import com.archos.mediacenter.utils.videodb.VideoDbInfo;
 import com.archos.mediacenter.video.browser.TorrentObserverService;
+import com.archos.mediacenter.video.player.ExternalPlayerService;
 import com.archos.mediacenter.video.player.PrivateMode;
 import com.archos.mediaprovider.video.VideoStore;
 import com.archos.mediascraper.ScrapeDetailResult;
@@ -107,6 +108,9 @@ public class ExternalPlayerResultListener implements ExternalPlayerWithResultSta
                 ", mVideoDbInfo!=null " + (mVideoDbInfo!=null) +
                 ", mPlayerUri " + mPlayerUri
         );
+
+        ExternalPlayerService.stopService(mContext);
+
         // Some external video player api specs:
         // vlc https://wiki.videolan.org/Android_Player_Intents/ https://wiki.videolan.org/MediaControlAPI
         // justplayer https://github.com/moneytoo/Player/issues/203

--- a/src/main/java/com/archos/mediacenter/video/utils/PlayUtils.java
+++ b/src/main/java/com/archos/mediacenter/video/utils/PlayUtils.java
@@ -19,23 +19,23 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import androidx.core.content.FileProvider;
-import androidx.preference.PreferenceManager;
-
 import android.os.Parcelable;
 import android.widget.Toast;
 
+import androidx.core.content.FileProvider;
+import androidx.preference.PreferenceManager;
+
+import com.archos.filecorelibrary.FileUtils;
 import com.archos.filecorelibrary.MetaFile2;
 import com.archos.filecorelibrary.MimeUtils;
 import com.archos.filecorelibrary.StreamOverHttp;
-import com.archos.filecorelibrary.FileUtils;
 import com.archos.mediacenter.filecoreextension.upnp2.StreamUriFinder;
 import com.archos.mediacenter.utils.videodb.IndexHelper;
 import com.archos.mediacenter.utils.videodb.VideoDbInfo;
-import com.archos.mediacenter.video.BuildConfig;
 import com.archos.mediacenter.video.R;
 import com.archos.mediacenter.video.browser.adapters.object.Video;
 import com.archos.mediacenter.video.browser.subtitlesmanager.SubtitleManager;
+import com.archos.mediacenter.video.player.ExternalPlayerService;
 import com.archos.mediacenter.video.player.PlayerActivity;
 import com.archos.mediacenter.video.player.PlayerService;
 import com.archos.mediacenter.video.player.TorrentLoaderActivity;
@@ -49,7 +49,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Created by vapillon on 15/04/15.
@@ -395,6 +394,7 @@ public class PlayUtils implements IndexHelper.Listener {
             } else {
                 ExternalPlayerResultListener.getInstance().init(context, video.getUri(), dataUri, mVideoDbInfo);
                 if (!((Activity) context).isFinishing()) {
+                    ExternalPlayerService.startService(context);
                     externalPlayerWithResultStarter.startActivityWithResultListener(intent);
                 }
             }


### PR DESCRIPTION
Android 14 introduced new background restrictions. Cached apps (those with no visible activity) are paused and cannot perform background work. For this reason, Nova’s HTTP server, which provides content to an external player, was being stopped. This commit adds a foreground service that starts before launching the external player and stops after the external player is closed. Thanks to the foreground service, Nova is considered an active app and is not paused by the system.

Fixes nova-video-player/aos-AVP#1426