### PR TITLE
Fix nova-video-player/aos-AVP#1386

### DIFF
--- a/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
+++ b/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
@@ -2983,7 +2983,7 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
 
             // get resume position only if video was played
             mLastPosition = getLastPosition(mVideoInfo, mResume);
-            if (!mCling) {
+            if (!mCling && mVideoInfo.title != null) {
                 mTitle = mVideoInfo.title;
             }
             mMovieOrShowName = null;


### PR DESCRIPTION
Fix nova-video-player/aos-AVP#1386 avoiding to overwrite the filename title with an empty metadata title