### PR TITLE
feat: add dynamic subtitle background and opacity control

### DIFF
--- a/res/layout/subtitle_settings_dialog.xml
+++ b/res/layout/subtitle_settings_dialog.xml
@@ -34,8 +34,8 @@
 
     <TextView
         android:id="@+id/subtitle_sample_text"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:clickable="false"
         android:focusable="false"
         android:focusableInTouchMode="false"
@@ -53,123 +53,159 @@
         android:textSize="22sp"
         android:textStyle="bold" />
 
-    <TextView
-        android:id="@+id/subtitle_size_text"
+    <!-- Scrollable area for all the settings -->
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/subtitles_settings_dialog_margin_small"
-        android:text="@string/subtitle_size_text" />
-    <RelativeLayout
-        android:id="@+id/seekbar_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" >
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
-        <ImageView
-            android:id="@+id/left_a"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignBottom="@+id/subtitle_size_seekbar"
-            android:layout_alignParentLeft="true"
-            android:layout_alignTop="@+id/subtitle_size_seekbar"
-            android:padding="@dimen/subtitles_settings_dialog_margin_large"
-            app:srcCompat="@drawable/video_info_arrow_down" />
+            android:orientation="vertical">
 
-        <SeekBar
-            android:id="@+id/subtitle_size_seekbar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_toLeftOf="@+id/right_a"
-            android:layout_toRightOf="@+id/left_a"
-            android:paddingBottom="@dimen/subtitles_settings_dialog_margin_large"
-            android:paddingTop="@dimen/subtitles_settings_dialog_margin_large" />
+            <TextView
+                android:id="@+id/subtitle_size_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/subtitles_settings_dialog_margin_small"
+                android:text="@string/subtitle_size_text" />
+            <RelativeLayout
+                android:id="@+id/seekbar_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" >
 
-        <ImageView
-            android:id="@+id/right_a"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignBottom="@+id/subtitle_size_seekbar"
-            android:layout_alignParentRight="true"
-            android:layout_alignTop="@+id/subtitle_size_seekbar"
-            android:padding="@dimen/subtitles_settings_dialog_margin_large"
-            app:srcCompat="@drawable/video_info_arrow_up" />
+                <ImageView
+                    android:id="@+id/left_a"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBottom="@+id/subtitle_size_seekbar"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignTop="@+id/subtitle_size_seekbar"
+                    android:padding="@dimen/subtitles_settings_dialog_margin_large"
+                    app:srcCompat="@drawable/video_info_arrow_down" />
 
-    </RelativeLayout>
+                <SeekBar
+                    android:id="@+id/subtitle_size_seekbar"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toLeftOf="@+id/right_a"
+                    android:layout_toRightOf="@+id/left_a"
+                    android:paddingBottom="@dimen/subtitles_settings_dialog_margin_large"
+                    android:paddingTop="@dimen/subtitles_settings_dialog_margin_large" />
+
+                <ImageView
+                    android:id="@+id/right_a"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBottom="@+id/subtitle_size_seekbar"
+                    android:layout_alignParentRight="true"
+                    android:layout_alignTop="@+id/subtitle_size_seekbar"
+                    android:padding="@dimen/subtitles_settings_dialog_margin_large"
+                    app:srcCompat="@drawable/video_info_arrow_up" />
+
+            </RelativeLayout>
     <!-- simple listDivider, should be using current Theme -->
 
-    <com.archos.mediacenter.video.player.SubtitleColorPicker
-        android:id="@+id/color_layout"
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"></com.archos.mediacenter.video.player.SubtitleColorPicker>
+            <com.archos.mediacenter.video.player.SubtitleColorPicker
+                android:id="@+id/color_layout"
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"></com.archos.mediacenter.video.player.SubtitleColorPicker>
 
-    <ImageView
-        android:layout_width="fill_parent"
-        android:layout_height="1px"
-        android:layout_marginBottom="@dimen/subtitles_settings_dialog_margin_large"
-        android:layout_marginTop="@dimen/subtitles_settings_dialog_margin_large"
-        android:scaleType="fitXY"
-        app:srcCompat="?android:attr/listDivider" />
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="1px"
+                android:layout_marginBottom="@dimen/subtitles_settings_dialog_margin_large"
+                android:layout_marginTop="@dimen/subtitles_settings_dialog_margin_large"
+                android:scaleType="fitXY"
+                app:srcCompat="?android:attr/listDivider" />
 
-    <!-- Vertical Positon v (seekbar) ^ -->
+<!-- Vertical Positon v (seekbar) ^ -->
 
-    <RelativeLayout
-        android:id="@+id/seekbar_container2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" >
+            <RelativeLayout
+                android:id="@+id/seekbar_container2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" >
 
-        <TextView
-            android:id="@+id/subtitle_vert_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/subtitles_settings_dialog_margin_small"
-            android:text="@string/subtitle_vert_text" />
+                <TextView
+                    android:id="@+id/subtitle_vert_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/subtitles_settings_dialog_margin_small"
+                    android:text="@string/subtitle_vert_text" />
 
-        <ImageView
-            android:id="@+id/left_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignBottom="@+id/subtitle_vert_seekbar"
-            android:layout_alignParentLeft="true"
-            android:layout_alignTop="@+id/subtitle_vert_seekbar"
-            android:padding="@dimen/subtitles_settings_dialog_margin_large"
-            app:srcCompat="@drawable/video_info_arrow_down" />
+                <ImageView
+                    android:id="@+id/left_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBottom="@+id/subtitle_vert_seekbar"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignTop="@+id/subtitle_vert_seekbar"
+                    android:padding="@dimen/subtitles_settings_dialog_margin_large"
+                    app:srcCompat="@drawable/video_info_arrow_down" />
 
-        <SeekBar
-            android:id="@+id/subtitle_vert_seekbar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/subtitle_vert_text"
-            android:layout_gravity="center_vertical"
-            android:layout_toLeftOf="@+id/right_icon"
-            android:layout_toRightOf="@+id/left_icon"
-            android:paddingBottom="@dimen/subtitles_settings_dialog_margin_large"
-            android:paddingTop="@dimen/subtitles_settings_dialog_margin_large" />
+                <SeekBar
+                    android:id="@+id/subtitle_vert_seekbar"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/subtitle_vert_text"
+                    android:layout_gravity="center_vertical"
+                    android:layout_toLeftOf="@+id/right_icon"
+                    android:layout_toRightOf="@+id/left_icon"
+                    android:paddingBottom="@dimen/subtitles_settings_dialog_margin_large"
+                    android:paddingTop="@dimen/subtitles_settings_dialog_margin_large" />
 
-        <ImageView
-            android:id="@+id/right_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignBottom="@+id/subtitle_vert_seekbar"
-            android:layout_alignParentRight="true"
-            android:layout_alignTop="@+id/subtitle_vert_seekbar"
-            android:padding="@dimen/subtitles_settings_dialog_margin_large"
-            app:srcCompat="@drawable/video_info_arrow_up" />
+                <ImageView
+                    android:id="@+id/right_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignBottom="@+id/subtitle_vert_seekbar"
+                    android:layout_alignParentRight="true"
+                    android:layout_alignTop="@+id/subtitle_vert_seekbar"
+                    android:padding="@dimen/subtitles_settings_dialog_margin_large"
+                    app:srcCompat="@drawable/video_info_arrow_up" />
 
-    </RelativeLayout>
+            </RelativeLayout>
 
-    <RelativeLayout
-        android:id="@+id/outline_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+            <LinearLayout
+                android:id="@+id/outline_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
-        <CheckBox
-            android:id="@+id/subOutline"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="false"
-            android:duplicateParentState="true"
-            android:text="@string/subtitle_outline" />
+                <CheckBox
+                    android:id="@+id/subOutline"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:checked="false"
+                    android:duplicateParentState="true"
+                    android:text="@string/subtitle_outline" />
+                
+                <CheckBox
+                    android:id="@+id/subBackground"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/subtitle_background_text" /> 
 
-    </RelativeLayout>
+                <TextView
+                    android:id="@+id/subtitle_bg_opacity_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginLeft="@dimen/subtitles_settings_dialog_margin_small"
+                    android:text="@string/subtitle_bg_opacity_text" />
+
+                <SeekBar
+                    android:id="@+id/subtitle_bg_opacity_seekbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+    </ScrollView>
 
 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -481,6 +481,8 @@
     <string name="subtitle_style_text">Style:</string>
     <string name="subtitle_vert_text">Vertical Position:</string>
     <string name="subtitle_outline">Outline subtitles</string>
+    <string name="subtitle_background_text">Subtitle Background</string>
+    <string name="subtitle_bg_opacity_text">Background Opacity</string>
     <!-- Subtitle Delay Dialog -->
     <string name="subtitle_delay_speed">Speed Adjustment</string>
     <string name="subtitle_delay_radio_none">none</string>

--- a/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
+++ b/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
@@ -1741,7 +1741,6 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
                 tvPicker2.postDelayed(r, 200);
             }
         });
-        
 
         tvmenu.createAndAddSeparator();
         final TVMenuItem tvm = tvmenu.createAndAddTVSwitchableMenuItem(getResources().getString(R.string.subtitle_outline), mSubtitleManager.getOutlineState());
@@ -1754,7 +1753,6 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
             }
         });
 
-        // [START] Subtitle Background Toggle
         final TVMenuItem tvmBg = tvmenu.createAndAddTVSwitchableMenuItem(getResources().getString(R.string.subtitle_background_text), mSubtitleManager.getBackgroundState()); // Make sure to add string resource or use literal "Subtitle Background"
         tvmBg.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -1764,42 +1762,28 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
                 mSubtitleManager.setBackgroundState(!bg);
             }
         });
-        // [END] Subtitle Background Toggle
 
-        // [START] Subtitle Background Opacity Picker
         tvmenu.createAndAddTVMenuItem(getResources().getString(R.string.subtitle_bg_opacity_text), false);
 
         final SubtitleDelayTVPicker tvPickerOpacity = (SubtitleDelayTVPicker) LayoutInflater.from(mContext)
                 .inflate(R.layout.subtitle_delay_tv_picker, null);
-        // Use a step of 1. Internally it becomes 100.
         tvPickerOpacity.setStep(1); 
         tvPickerOpacity.setMin(0);
-        // Max is 255. Internally it expects this multiplied by 100
         tvPickerOpacity.setMax(255 * 100); 
         tvmenu.addTVMenuItem(tvPickerOpacity);
         tvPickerOpacity.setTextViewWidth((int) pickerWidth);
-        
-        // Stop it from formatting the time string "0s"
         tvPickerOpacity.setUpdateText(false);
-        // Set the initial text
         tvPickerOpacity.setText(String.valueOf(mSubtitleManager.getBackgroundOpacity()));
-
-        // Initialize with the current opacity * 100
         tvPickerOpacity.init(mSubtitleManager.getBackgroundOpacity() * 100, new SubtitleDelayPickerAbstract.OnDelayChangedListener() {
             @Override
             public void onDelayChanged(SubtitleDelayPickerAbstract view, int delay) {
-                // The delay comes back multiplied by 100
                 int opacity = delay / 100;
-                // Keep bounds
                 if (opacity < 0) opacity = 0;
                 if (opacity > 255) opacity = 255;
-
                 mSubtitleManager.setBackgroundOpacity(opacity);
-                // Manually update the text
                 tvPickerOpacity.setText(String.valueOf(opacity));
             }
         });
-        // [END] Subtitle Background Opacity Picker
 
         ((TVCardDialog)dialogMainView.findViewById(R.id.card_view)).addOtherView(tvmenu);
         ((TVCardDialog)dialogMainView.findViewById(R.id.card_view)).setOnDialogResultListener(new TVCardDialog.OnDialogResultListener() {     

--- a/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
+++ b/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
@@ -174,6 +174,8 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
     private static final int DIALOG_AUDIO_SPEED = 10;
 
     // accessed from SubtitleSettingsDialog
+    public static final String KEY_SUBTITLE_BACKGROUND = "subtitle_background";
+    public static final String KEY_SUBTITLE_BG_OPACITY = "subtitle_bg_opacity";
     /* package */ public static final String KEY_SUBTITLE_SIZE = "pref_play_subtitle_size_key";
     /* package */ public static final String KEY_SUBTITLE_VPOS = "pref_play_subtitle_vpos_key";
     public static final String KEY_SUBTITLE_OUTLINE = "pref_play_subtitle_outline_key";
@@ -1739,6 +1741,7 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
                 tvPicker2.postDelayed(r, 200);
             }
         });
+        
 
         tvmenu.createAndAddSeparator();
         final TVMenuItem tvm = tvmenu.createAndAddTVSwitchableMenuItem(getResources().getString(R.string.subtitle_outline), mSubtitleManager.getOutlineState());
@@ -1751,6 +1754,53 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
             }
         });
 
+        // [START] Subtitle Background Toggle
+        final TVMenuItem tvmBg = tvmenu.createAndAddTVSwitchableMenuItem(getResources().getString(R.string.subtitle_background_text), mSubtitleManager.getBackgroundState()); // Make sure to add string resource or use literal "Subtitle Background"
+        tvmBg.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                boolean bg = mSubtitleManager.getBackgroundState();
+                tvmBg.setChecked(!bg);
+                mSubtitleManager.setBackgroundState(!bg);
+            }
+        });
+        // [END] Subtitle Background Toggle
+
+        // [START] Subtitle Background Opacity Picker
+        tvmenu.createAndAddTVMenuItem(getResources().getString(R.string.subtitle_bg_opacity_text), false);
+
+        final SubtitleDelayTVPicker tvPickerOpacity = (SubtitleDelayTVPicker) LayoutInflater.from(mContext)
+                .inflate(R.layout.subtitle_delay_tv_picker, null);
+        // Use a step of 1. Internally it becomes 100.
+        tvPickerOpacity.setStep(1); 
+        tvPickerOpacity.setMin(0);
+        // Max is 255. Internally it expects this multiplied by 100
+        tvPickerOpacity.setMax(255 * 100); 
+        tvmenu.addTVMenuItem(tvPickerOpacity);
+        tvPickerOpacity.setTextViewWidth((int) pickerWidth);
+        
+        // Stop it from formatting the time string "0s"
+        tvPickerOpacity.setUpdateText(false);
+        // Set the initial text
+        tvPickerOpacity.setText(String.valueOf(mSubtitleManager.getBackgroundOpacity()));
+
+        // Initialize with the current opacity * 100
+        tvPickerOpacity.init(mSubtitleManager.getBackgroundOpacity() * 100, new SubtitleDelayPickerAbstract.OnDelayChangedListener() {
+            @Override
+            public void onDelayChanged(SubtitleDelayPickerAbstract view, int delay) {
+                // The delay comes back multiplied by 100
+                int opacity = delay / 100;
+                // Keep bounds
+                if (opacity < 0) opacity = 0;
+                if (opacity > 255) opacity = 255;
+
+                mSubtitleManager.setBackgroundOpacity(opacity);
+                // Manually update the text
+                tvPickerOpacity.setText(String.valueOf(opacity));
+            }
+        });
+        // [END] Subtitle Background Opacity Picker
+
         ((TVCardDialog)dialogMainView.findViewById(R.id.card_view)).addOtherView(tvmenu);
         ((TVCardDialog)dialogMainView.findViewById(R.id.card_view)).setOnDialogResultListener(new TVCardDialog.OnDialogResultListener() {     
             @Override
@@ -1759,6 +1809,8 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
                 mPreferences.edit().putInt( PlayerActivity.KEY_SUBTITLE_VPOS, mSubtitleManager.getVerticalPosition()).apply();
                 mPreferences.edit().putInt( PlayerActivity.KEY_SUBTITLE_COLOR, mSubtitleManager.getColor()).apply();
                 mPreferences.edit().putBoolean(PlayerActivity.KEY_SUBTITLE_OUTLINE, mSubtitleManager.getOutlineState()).apply();
+                mPreferences.edit().putBoolean(PlayerActivity.KEY_SUBTITLE_BACKGROUND, mSubtitleManager.getBackgroundState()).apply();
+                mPreferences.edit().putInt(PlayerActivity.KEY_SUBTITLE_BG_OPACITY, mSubtitleManager.getBackgroundOpacity()).apply();
                 mPlayerController.getTVMenuAdapter().setDiscrete(false);
                 mSubtitleManager.fadeSubtitlePositionHint(false);
             }
@@ -4163,6 +4215,10 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
                 mSubtitleManager.setColor(color);
                 setSubtitleVpos(vpos, "onSubtitleMetadataUpdated");
                 mSubtitleManager.setOutlineState(outline);
+                boolean background = preferences.getBoolean(KEY_SUBTITLE_BACKGROUND, false);
+                int bgOpacity = preferences.getInt(KEY_SUBTITLE_BG_OPACITY, 128);
+                mSubtitleManager.setBackgroundState(background);
+                mSubtitleManager.setBackgroundOpacity(bgOpacity);
                 // mVideoInfo.subtitleTrack is the track number with the none track 0<=mVideoInfo.subtitleTrack<=nbTrack, nbTrack for none track
                 // but mSubtitleInfoController is the track number with the none track (i.e. nbTrack + 1) at position 0
                 // at this point mVideoInfo.subtitleTrack is the track number to be used

--- a/src/main/java/com/archos/mediacenter/video/player/Subtitle3DTextView.java
+++ b/src/main/java/com/archos/mediacenter/video/player/Subtitle3DTextView.java
@@ -135,6 +135,16 @@ public class Subtitle3DTextView extends LinearLayout {
         mSecondaryTV.setOutlineState(outline);
     }
 
+    public void setBackgroundState(boolean show) {
+        mPrimaryTV.setBackgroundState(show);
+        mSecondaryTV.setBackgroundState(show);
+    }
+
+    public void setBackgroundOpacity(int opacity) {
+        mPrimaryTV.setBackgroundOpacity(opacity);
+        mSecondaryTV.setBackgroundOpacity(opacity);
+    }
+    
     public void setTextSize(float v) {
         mPrimaryTV.setTextSize(v);
         mSecondaryTV.setTextSize(v);

--- a/src/main/java/com/archos/mediacenter/video/player/SubtitleManager.java
+++ b/src/main/java/com/archos/mediacenter/video/player/SubtitleManager.java
@@ -277,8 +277,8 @@ public class SubtitleManager {
 
     private int mColor;
     private boolean mOutline;
-    private boolean mBackground = false; // Add this
-    private int mBgOpacity = 128;        // Add this (default 50%)
+    private boolean mBackground;
+    private int mBgOpacity;
     private int mUiMode;
 
     private void removeSubtitle(Subtitle subtitle) {
@@ -394,7 +394,7 @@ public class SubtitleManager {
     public void setBackgroundState(boolean background) {
         mBackground = background;
         if (mSubtitleTxtView != null) {
-            mSubtitleTxtView.setBackgroundState(background); // Passes state to the View
+            mSubtitleTxtView.setBackgroundState(background);
         }
     }
 
@@ -405,7 +405,7 @@ public class SubtitleManager {
     public void setBackgroundOpacity(int opacity) {
         mBgOpacity = opacity;
         if (mSubtitleTxtView != null) {
-            mSubtitleTxtView.setBackgroundOpacity(opacity); // Passes opacity to the View
+            mSubtitleTxtView.setBackgroundOpacity(opacity); 
         }
     }
 

--- a/src/main/java/com/archos/mediacenter/video/player/SubtitleManager.java
+++ b/src/main/java/com/archos/mediacenter/video/player/SubtitleManager.java
@@ -277,6 +277,8 @@ public class SubtitleManager {
 
     private int mColor;
     private boolean mOutline;
+    private boolean mBackground = false; // Add this
+    private int mBgOpacity = 128;        // Add this (default 50%)
     private int mUiMode;
 
     private void removeSubtitle(Subtitle subtitle) {
@@ -382,6 +384,28 @@ public class SubtitleManager {
         mOutline = outline;
         if (mSubtitleTxtView != null) {
             mSubtitleTxtView.setOutlineState(outline);
+        }
+    }
+
+    public boolean getBackgroundState() { 
+        return mBackground; 
+    }
+
+    public void setBackgroundState(boolean background) {
+        mBackground = background;
+        if (mSubtitleTxtView != null) {
+            mSubtitleTxtView.setBackgroundState(background); // Passes state to the View
+        }
+    }
+
+    public int getBackgroundOpacity() { 
+        return mBgOpacity; 
+    }
+
+    public void setBackgroundOpacity(int opacity) {
+        mBgOpacity = opacity;
+        if (mSubtitleTxtView != null) {
+            mSubtitleTxtView.setBackgroundOpacity(opacity); // Passes opacity to the View
         }
     }
 
@@ -629,6 +653,8 @@ public class SubtitleManager {
         if (mSubtitleSpacer == null || mSubtitleGfxView == null || mSubtitleTxtView == null) return;
         mSubtitleTxtView.setScreenSize(mScreenWidth, mScreenHeight);
         mSubtitleTxtView.setUIMode(mUiMode);
+        mSubtitleTxtView.setBackgroundState(mBackground);
+        mSubtitleTxtView.setBackgroundOpacity(mBgOpacity);
         mSubtitleSpacerParams = mSubtitleSpacer.getLayoutParams();
         if (log.isDebugEnabled()) log.debug("attachWindow: mSubtitleSpacerParams.height={}", mSubtitleSpacerParams.height);
         mSubtitleSpacerParams.height = mSubtitleEvadedVPos;

--- a/src/main/java/com/archos/mediacenter/video/player/SubtitleSettingsDialog.java
+++ b/src/main/java/com/archos/mediacenter/video/player/SubtitleSettingsDialog.java
@@ -69,6 +69,10 @@ public class SubtitleSettingsDialog extends AlertDialog implements
     };
     private View mTouchedView;
     private int mColor;
+    private CheckBox mSubBackgroundCheckBox;
+    private SeekBar mBgOpacitySeekBar;
+    private boolean mBackground = false;
+    private int mBgOpacity = 128; // Default 50% opacity
 
     public SubtitleSettingsDialog(Context context, SubtitleManager subtitleManager) {
         super(context);
@@ -125,6 +129,23 @@ public class SubtitleSettingsDialog extends AlertDialog implements
             }
         });
 
+        // Background Toggle
+        mSubBackgroundCheckBox = view.findViewById(R.id.subBackground);
+        mBackground = mSubtitleManager.getBackgroundState(); // You'll need to create this getter in SubtitleManager
+        mSubBackgroundCheckBox.setChecked(mBackground);
+        mSubBackgroundCheckBox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mBackground = mSubBackgroundCheckBox.isChecked();
+                mSubtitleManager.setBackgroundState(mBackground); 
+            }
+        });
+
+        // Opacity Slider
+        mBgOpacitySeekBar = (SeekBar) view.findViewById(R.id.subtitle_bg_opacity_seekbar);
+        mBgOpacitySeekBar.setMax(255); // Alpha range is 0-255
+        mBgOpacitySeekBar.setOnSeekBarChangeListener(this);
+
         setCancelable(true);
         setCanceledOnTouchOutside(true);
 
@@ -156,6 +177,11 @@ public class SubtitleSettingsDialog extends AlertDialog implements
                 }
                 mSubtitleManager.setVerticalPosition(progress);
             }
+        } else if (seekBar == mBgOpacitySeekBar) {
+            mBgOpacity = progress;
+            if (mSubtitleManager != null) {
+                mSubtitleManager.setBackgroundOpacity(progress);
+            }
         } else {
             // wtf
         }
@@ -184,6 +210,8 @@ public class SubtitleSettingsDialog extends AlertDialog implements
         mSharedPreferences.edit().putInt(PlayerActivity.KEY_SUBTITLE_VPOS, mVPos).apply();
         mSharedPreferences.edit().putBoolean(PlayerActivity.KEY_SUBTITLE_OUTLINE, mOutline).apply();
         mSubtitleManager.fadeSubtitlePositionHint(false);
+        mSharedPreferences.edit().putBoolean(PlayerActivity.KEY_SUBTITLE_BACKGROUND, mBackground).apply();
+        mSharedPreferences.edit().putInt(PlayerActivity.KEY_SUBTITLE_BG_OPACITY, mBgOpacity).apply();
         super.onDetachedFromWindow();
     }
 
@@ -200,6 +228,8 @@ public class SubtitleSettingsDialog extends AlertDialog implements
 
         // Force the initial focus on the size slider
         mSizeSeekBar.requestFocus();
+        mSubBackgroundCheckBox.setChecked(mSubtitleManager.getBackgroundState());
+        mBgOpacitySeekBar.setProgress(mSubtitleManager.getBackgroundOpacity());
     }
 
     public void onAction(View view) {

--- a/src/main/java/com/archos/mediacenter/video/player/SubtitleSettingsDialog.java
+++ b/src/main/java/com/archos/mediacenter/video/player/SubtitleSettingsDialog.java
@@ -71,8 +71,8 @@ public class SubtitleSettingsDialog extends AlertDialog implements
     private int mColor;
     private CheckBox mSubBackgroundCheckBox;
     private SeekBar mBgOpacitySeekBar;
-    private boolean mBackground = false;
-    private int mBgOpacity = 128; // Default 50% opacity
+    private boolean mBackground;
+    private int mBgOpacity;
 
     public SubtitleSettingsDialog(Context context, SubtitleManager subtitleManager) {
         super(context);
@@ -129,10 +129,10 @@ public class SubtitleSettingsDialog extends AlertDialog implements
             }
         });
 
-        // Background Toggle
         mSubBackgroundCheckBox = view.findViewById(R.id.subBackground);
-        mBackground = mSubtitleManager.getBackgroundState(); // You'll need to create this getter in SubtitleManager
+        mBackground = mSubtitleManager.getBackgroundState();
         mSubBackgroundCheckBox.setChecked(mBackground);
+        mBgOpacity = mSubtitleManager.getBackgroundOpacity();
         mSubBackgroundCheckBox.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -141,9 +141,8 @@ public class SubtitleSettingsDialog extends AlertDialog implements
             }
         });
 
-        // Opacity Slider
         mBgOpacitySeekBar = (SeekBar) view.findViewById(R.id.subtitle_bg_opacity_seekbar);
-        mBgOpacitySeekBar.setMax(255); // Alpha range is 0-255
+        mBgOpacitySeekBar.setMax(255);
         mBgOpacitySeekBar.setOnSeekBarChangeListener(this);
 
         setCancelable(true);

--- a/src/main/java/com/archos/mediacenter/video/player/SubtitleTextView.java
+++ b/src/main/java/com/archos/mediacenter/video/player/SubtitleTextView.java
@@ -35,10 +35,9 @@ public class SubtitleTextView extends AppCompatTextView {
 
     private static boolean mOutline = false;
     private final Paint mBgPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-    private boolean mShowBackground = false;
-    private int mBgOpacity = 128;
+    private boolean mShowBackground;
+    private int mBgOpacity;
 
-    // Reused objects to prevent memory allocation during onDraw
     private Rect r = new Rect();
     private int[] location = new int[2];
     private final RectF mBgRect = new RectF();
@@ -46,7 +45,7 @@ public class SubtitleTextView extends AppCompatTextView {
     public SubtitleTextView(Context context, AttributeSet attrs) {
         super(context, attrs);
         mBgPaint.setStyle(Paint.Style.FILL);
-        mBgPaint.setColor(android.graphics.Color.argb(128, 0, 0, 0)); // 50% black
+        mBgPaint.setColor(android.graphics.Color.argb(128, 0, 0, 0));
         setLineSpacing(0f, 1.15f);
     }
 
@@ -57,7 +56,7 @@ public class SubtitleTextView extends AppCompatTextView {
 
     public void setBackgroundOpacity(int opacity) { 
         mBgOpacity = opacity;
-        mBgPaint.setAlpha(mBgOpacity); // Updates the Paint opacity dynamically
+        mBgPaint.setAlpha(mBgOpacity);
         invalidate(); 
     }
 
@@ -107,11 +106,9 @@ public class SubtitleTextView extends AppCompatTextView {
             float padY = getTextSize() * 0.02f;
             float radius = getTextSize() * 0.15f;
             float gapY = getTextSize() * 0.08f;
-            
             float offsetX = getTotalPaddingLeft() + getScrollX();
             float offsetY = getTotalPaddingTop() + getScrollY();
 
-            // Find the last line that actually contains text
             int lastTextLine = -1;
             for (int i = 0; i < layout.getLineCount(); i++) {
                 if (layout.getLineRight(i) > layout.getLineLeft(i)) {
@@ -126,7 +123,6 @@ public class SubtitleTextView extends AppCompatTextView {
                 if (right > left) {
                     float top = layout.getLineTop(i);
                     float bottom = layout.getLineBottom(i);
-                    
                     // Reduce the bottom of all lines EXCEPT the last one
                     if (i < lastTextLine) {
                         bottom -= gapY; 

--- a/src/main/java/com/archos/mediacenter/video/player/SubtitleTextView.java
+++ b/src/main/java/com/archos/mediacenter/video/player/SubtitleTextView.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.RectF;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.text.TextPaint;
@@ -33,9 +34,31 @@ public class SubtitleTextView extends AppCompatTextView {
     private Surface mExternalSurface = null;
 
     private static boolean mOutline = false;
-   
+    private final Paint mBgPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private boolean mShowBackground = false;
+    private int mBgOpacity = 128;
+
+    // Reused objects to prevent memory allocation during onDraw
+    private Rect r = new Rect();
+    private int[] location = new int[2];
+    private final RectF mBgRect = new RectF();
+
     public SubtitleTextView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        mBgPaint.setStyle(Paint.Style.FILL);
+        mBgPaint.setColor(android.graphics.Color.argb(128, 0, 0, 0)); // 50% black
+        setLineSpacing(0f, 1.15f);
+    }
+
+    public void setBackgroundState(boolean show) { 
+        mShowBackground = show; 
+        invalidate(); 
+    }
+
+    public void setBackgroundOpacity(int opacity) { 
+        mBgOpacity = opacity;
+        mBgPaint.setAlpha(mBgOpacity); // Updates the Paint opacity dynamically
+        invalidate(); 
     }
 
     public void setOutlineState(boolean outline) { mOutline = outline; }
@@ -59,9 +82,6 @@ public class SubtitleTextView extends AppCompatTextView {
         mExternalSurface = s;
     }
 
-    private Rect r = new Rect();
-    private int[] location = new int[2];
-
     @Override
     protected void onDraw(Canvas canvas) {
         Canvas c = canvas;
@@ -78,6 +98,51 @@ public class SubtitleTextView extends AppCompatTextView {
             } catch (Exception ignored) {
             }
         }
+        
+        // Draw black background behind subtitle text line-by-line
+        if (mShowBackground && getLayout() != null) {
+            android.text.Layout layout = getLayout();
+            
+            float padX = getTextSize() * 0.25f;
+            float padY = getTextSize() * 0.02f;
+            float radius = getTextSize() * 0.15f;
+            float gapY = getTextSize() * 0.08f;
+            
+            float offsetX = getTotalPaddingLeft() + getScrollX();
+            float offsetY = getTotalPaddingTop() + getScrollY();
+
+            // Find the last line that actually contains text
+            int lastTextLine = -1;
+            for (int i = 0; i < layout.getLineCount(); i++) {
+                if (layout.getLineRight(i) > layout.getLineLeft(i)) {
+                    lastTextLine = i;
+                }
+            }
+
+            for (int i = 0; i < layout.getLineCount(); i++) {
+                float left = layout.getLineLeft(i);
+                float right = layout.getLineRight(i);
+                
+                if (right > left) {
+                    float top = layout.getLineTop(i);
+                    float bottom = layout.getLineBottom(i);
+                    
+                    // Reduce the bottom of all lines EXCEPT the last one
+                    if (i < lastTextLine) {
+                        bottom -= gapY; 
+                    }
+                    mBgRect.set(
+                        left + offsetX - padX,
+                        top + offsetY - padY,
+                        right + offsetX + padX,
+                        bottom + offsetY + padY
+                    );
+
+                    c.drawRoundRect(mBgRect, radius, radius, mBgPaint); 
+                }
+            }
+        }
+
         // disable for now nice outline since it is too slow on lowend CPU/GPU (e.g. RK3128)
         if (mOutline) {
             TextPaint paint = getPaint();

--- a/src/main/java/com/archos/mediacenter/video/player/tvmenu/TVMenu.java
+++ b/src/main/java/com/archos/mediacenter/video/player/tvmenu/TVMenu.java
@@ -109,7 +109,7 @@ public class TVMenu extends LinearLayout implements FocusableTVCardView, TVSlave
         updateCurrentFocusIndex();
         if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
             int nextIndex = current + 1;
-            while (nextIndex < ti.size() && (!ti.get(nextIndex).isEnabled() || isSeparator(ti.get(nextIndex)))) {
+            while (nextIndex < ti.size() && (!ti.get(nextIndex).isEnabled() || !ti.get(nextIndex).isFocusable() || isSeparator(ti.get(nextIndex)))) {
                 nextIndex++;
             }
             if (nextIndex < ti.size()) {
@@ -119,7 +119,7 @@ public class TVMenu extends LinearLayout implements FocusableTVCardView, TVSlave
             }
         } else if (keyCode == KeyEvent.KEYCODE_DPAD_UP) {
             int prevIndex = current - 1;
-            while (prevIndex >= 0 && (!ti.get(prevIndex).isEnabled() || isSeparator(ti.get(prevIndex)))) {
+            while (prevIndex >= 0 && (!ti.get(prevIndex).isEnabled() || !ti.get(prevIndex).isFocusable() || isSeparator(ti.get(prevIndex)))) {
                 prevIndex--;
             }
             if (prevIndex >= 0) {


### PR DESCRIPTION
This is the most requested feature. Although the translations for the new strings need to be added, it works well on TV and mobile. It only woeks on text based subtitles.

The new options are placed in the existing subtitle settings menu in the video player.
<img width="720" height="727" alt="photo_2026-05-04_09-34-59" src="https://github.com/user-attachments/assets/f3ebf967-5bd0-4b7c-8d36-01ff0a50e772" />
there are two new options
1. Enable/disable subtitle background
2. Subtitle background opacity.


requested in:
nova-video-player/aos-AVP#1624
nova-video-player/aos-AVP#1538
nova-video-player/aos-AVP#1267
nova-video-player/aos-AVP#854

Debug APK for testing: [PixelDrain](https://pixeldrain.com/u/1p6WuAHR)
Hope it gets merged soon.
Thanks