### PR TITLE
Fix malformed IMDb links in Spanish locale

### DIFF
--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -237,7 +237,7 @@
     <string name="scraper_no_movie_button_label">Buscar información en línea de la película</string>
     <string name="scraper_no_tv_show_text">Actualmente no tienes cartel e información para tus series</string>
     <string name="scraper_no_tv_show_button_label">Buscar información en línea de la serie</string>
-    <string name="imdb_title_url">https://www.imdb.com</string>
+    <string name="imdb_title_url">https://www.imdb.com/title/</string>
     <!-- To be translated only in case there is a localized IMDB -->
     <string name="storage">Almacenamiento</string>
     <string name="rescan_storage">Volver a escanear almacenamiento</string>


### PR DESCRIPTION
## Summary

Fix the Spanish `imdb_title_url` resource so IMDb links point to the title route.

## Root cause

The Spanish locale defined the base URL as `https://www.imdb.com`. The app appends an IMDb ID directly, producing malformed URLs such as `https://imdb.comtt14364480`.

## User impact

Spanish-language Android TV and Google TV users can open IMDb links correctly. For example, `tt14364480` now resolves to `https://www.imdb.com/title/tt14364480`.

## Validation

- Parsed `res/values-es/strings.xml` successfully as XML.
- Ran `git diff --check`.
- Confirmed the resource now matches the valid IMDb title base used by other locales.