### PR TITLE
Add video orientation setting and settings search

### DIFF
--- a/res/layout/preferences_video.xml
+++ b/res/layout/preferences_video.xml
@@ -1,11 +1,28 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/preferences_search"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/preferences_search_hint"
+        android:inputType="text"
+        android:imeOptions="actionDone"
+        android:maxLines="1"
+        android:drawableStart="@android:drawable/ic_menu_search"
+        android:drawablePadding="8dp"
+        android:paddingLeft="12dp"
+        android:paddingRight="12dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="4dp" />
 
     <fragment
         android:id="@+id/preferencesFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         class="com.archos.mediacenter.video.utils.VideoPreferencesFragment" />
 
-</RelativeLayout>
+</LinearLayout>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -525,6 +525,12 @@
     <string name="preferences_about">О программе</string>
     <string name="preferences_category_complete">Полная версия</string>
     <string name="preferences_category_video">Видео</string>
+    <string name="pref_video_orientation_title">Ориентация видео</string>
+    <string name="pref_video_orientation_summary">Положение видео на экране: горизонтальное или вертикальное</string>
+    <string name="pref_video_orientation_auto">Авто</string>
+    <string name="pref_video_orientation_landscape">Горизонтально</string>
+    <string name="pref_video_orientation_portrait">Вертикально</string>
+    <string name="preferences_search_hint">Поиск по настройкам</string>
     <string name="preferences_force_software_decoding">Принудительное программное декодирование</string>
     <string name="preferences_force_software_decoding_summary">Вы можете попробовать эту опцию, если некоторые видео проигрываются не правильно</string>
     <string name="preferences_force_audio_passthrough">Прямой проброс звука</string>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -109,6 +109,18 @@
         <item>system</item>
     </string-array>
 
+    <string-array name="video_orientation_entries">
+        <item>@string/pref_video_orientation_auto</item>
+        <item>@string/pref_video_orientation_landscape</item>
+        <item>@string/pref_video_orientation_portrait</item>
+    </string-array>
+
+    <string-array name="video_orientation_entryvalues">
+        <item>auto</item>
+        <item>landscape</item>
+        <item>portrait</item>
+    </string-array>
+
     <string-array name="dec_choice_entries">
         <item>@string/dec_any</item>
         <item>@string/dec_hw_mediacodec</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -587,6 +587,12 @@
     <string name="preferences_about">About</string>
     <string name="preferences_category_complete">Full version</string>
     <string name="preferences_category_video">Video</string>
+    <string name="pref_video_orientation_title">Video orientation</string>
+    <string name="pref_video_orientation_summary">Set the video position on the screen: landscape or portrait</string>
+    <string name="pref_video_orientation_auto">Auto</string>
+    <string name="pref_video_orientation_landscape">Landscape (horizontal)</string>
+    <string name="pref_video_orientation_portrait">Portrait (vertical)</string>
+    <string name="preferences_search_hint">Search settings</string>
     <string name="preferences_force_software_decoding">Force software decoding</string>
     <string name="preferences_force_software_decoding_summary">You may try this option if some videos are not playing correctly</string>
     <string name="preferences_force_audio_passthrough">Audio passthrough</string>

--- a/res/xml/preferences_video.xml
+++ b/res/xml/preferences_video.xml
@@ -25,6 +25,15 @@
         android:key="preferences_category_video"
         android:title="@string/preferences_category_video"
         app:iconSpaceReserved="false">
+        <ListPreference
+            android:defaultValue="auto"
+            android:entries="@array/video_orientation_entries"
+            android:entryValues="@array/video_orientation_entryvalues"
+            android:key="pref_video_orientation"
+            android:persistent="true"
+            android:summary="@string/pref_video_orientation_summary"
+            android:title="@string/pref_video_orientation_title"
+            app:iconSpaceReserved="false"/>
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="force_software_decoding"

--- a/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
+++ b/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
@@ -895,7 +895,7 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
         }
         else{
             if (log.isDebugEnabled()) log.debug("setEffect: setLockRotation {}", mLockRotation);
-            setLockRotation(mLockRotation);
+            setOrientationFromPreference();
         }
     }
 

--- a/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
+++ b/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
@@ -1476,15 +1476,22 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
         if (log.isDebugEnabled()) log.debug("CONFIG setOrientationFromPreference: {}", orientation);
         switch (orientation) {
             case "portrait":
+                resetRotationLockState();
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
                 break;
             case "landscape":
+                resetRotationLockState();
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
                 break;
             default:
                 setLockRotation(mLockRotation);
                 break;
         }
+    }
+
+    private void resetRotationLockState() {
+        mIsRotationLocked = false;
+        mLockedRotation = Surface.ROTATION_0;
     }
 
     @SuppressWarnings("deprecation") // getDefaultDisplay: API 30+ uses getDisplay()
@@ -2625,6 +2632,9 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
             mBookmarkMenuItem.setVisible(canSetBookmark());
         if (menu.findItem(MENU_S3D_ID) != null)
             menu.findItem(MENU_S3D_ID).setVisible(isStereoEffectOn());
+        if (menu.findItem(MENU_LOCK_ROTATION_ID) != null) {
+            menu.findItem(MENU_LOCK_ROTATION_ID).setVisible("auto".equals(mPreferences.getString(KEY_VIDEO_ORIENTATION, "auto")));
+        }
         if (menu.findItem(MENU_SPATIALIZATION_ID) != null) {
             menu.findItem(MENU_SPATIALIZATION_ID).setChecked(isSpatializationEnabledForPlayback());
             menu.findItem(MENU_SPATIALIZATION_ID).setEnabled(isSpatializationToggleAvailable());

--- a/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
+++ b/src/main/java/com/archos/mediacenter/video/player/PlayerActivity.java
@@ -198,6 +198,7 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
     private static final String KEY_NOTIFICATIONS_MODE = "notifications_mode";
     private static final String KEY_NETWORK_BOOKMARKS = "network_bookmarks";
     private static final String KEY_LOCK_ROTATION = "pref_lock_rotation";
+    private static final String KEY_VIDEO_ORIENTATION = "pref_video_orientation";
     public static final String KEY_ADVANCED_VIDEO_ENABLED = "preferences_advanced_video_enabled";
 
     public static final String INDEXED_URI = "indexed_uri";
@@ -937,7 +938,7 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
         mNetworkBookmarksEnabled = mPreferences.getBoolean(KEY_NETWORK_BOOKMARKS, true);
         mForceSWDecoding = mPreferences.getBoolean(KEY_FORCE_SW, false);
         if (log.isDebugEnabled()) log.debug("onStart: setLockRotation {}", mLockRotation);
-        setLockRotation(mLockRotation);
+        setOrientationFromPreference();
         mSurfaceController.setVideoFormat(Integer.parseInt(mPreferences.getString(KEY_PLAYER_FORMAT, "-1")),
                 Integer.parseInt(mPreferences.getString(KEY_PLAYER_AUTO_FORMAT, "-1")));
         
@@ -1468,6 +1469,22 @@ public class PlayerActivity extends AppCompatActivity implements PlayerControlle
             case ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED -> "unspecified";
             default -> "";
         };
+    }
+
+    private void setOrientationFromPreference() {
+        String orientation = mPreferences.getString(KEY_VIDEO_ORIENTATION, "auto");
+        if (log.isDebugEnabled()) log.debug("CONFIG setOrientationFromPreference: {}", orientation);
+        switch (orientation) {
+            case "portrait":
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+                break;
+            case "landscape":
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+                break;
+            default:
+                setLockRotation(mLockRotation);
+                break;
+        }
     }
 
     @SuppressWarnings("deprecation") // getDefaultDisplay: API 30+ uses getDisplay()

--- a/src/main/java/com/archos/mediacenter/video/utils/VideoPreferencesFragment.java
+++ b/src/main/java/com/archos/mediacenter/video/utils/VideoPreferencesFragment.java
@@ -14,7 +14,6 @@
 package com.archos.mediacenter.video.utils;
 
 import android.annotation.SuppressLint;
-import android.content.Intent;
 import android.graphics.Insets;
 import android.os.Build;
 import android.os.Bundle;
@@ -37,10 +36,13 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.archos.mediacenter.video.CustomApplication;
 import com.archos.mediacenter.video.R;
 
+import java.util.IdentityHashMap;
 import java.util.Locale;
 
 public class VideoPreferencesFragment extends PreferenceFragmentCompat {
 
+    private final IdentityHashMap<Preference, Boolean> mOriginalVisibility = new IdentityHashMap<>();
+    private boolean mVisibilitySnapshotted = false;
     private VideoPreferencesCommon mPreferencesCommon = new VideoPreferencesCommon(this);
 
     @Override
@@ -129,39 +131,55 @@ public class VideoPreferencesFragment extends PreferenceFragmentCompat {
         mPreferencesCommon.onSaveInstanceState(outState);
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        mPreferencesCommon.onActivityResult(requestCode, resultCode, data);
-    }
-
     private void filterPreferences(String query) {
         PreferenceScreen screen = getPreferenceScreen();
         if (screen == null) return;
-        filterGroup(screen, query == null ? "" : query.trim());
+        if (!mVisibilitySnapshotted) {
+            snapshotVisibility(screen);
+            mVisibilitySnapshotted = true;
+        }
+        String q = query == null ? "" : query.trim().toLowerCase(Locale.ROOT);
+        if (q.isEmpty()) {
+            restoreVisibility(screen);
+            return;
+        }
+        filterGroup(screen, q);
+    }
+
+    private void snapshotVisibility(PreferenceGroup group) {
+        mOriginalVisibility.put(group, group.isVisible());
+        for (int j = 0; j < group.getPreferenceCount(); j++) {
+            Preference child = group.getPreference(j);
+            mOriginalVisibility.put(child, child.isVisible());
+            if (child instanceof PreferenceGroup) {
+                snapshotVisibility((PreferenceGroup) child);
+            }
+        }
+    }
+
+    private void restoreVisibility(PreferenceGroup group) {
+        Boolean groupVisible = mOriginalVisibility.get(group);
+        if (groupVisible != null) group.setVisible(groupVisible);
+        for (int j = 0; j < group.getPreferenceCount(); j++) {
+            Preference child = group.getPreference(j);
+            Boolean childVisible = mOriginalVisibility.get(child);
+            if (childVisible != null) child.setVisible(childVisible);
+            if (child instanceof PreferenceGroup) {
+                restoreVisibility((PreferenceGroup) child);
+            }
+        }
     }
 
     private void filterGroup(PreferenceGroup group, String q) {
-        if (q.isEmpty()) {
-            group.setVisible(true);
-            for (int j = 0; j < group.getPreferenceCount(); j++) {
-                Preference child = group.getPreference(j);
-                if (child instanceof PreferenceGroup) {
-                    filterGroup((PreferenceGroup) child, q);
-                } else {
-                    child.setVisible(true);
-                }
-            }
-            return;
-        }
         if (matchesQuery(group, q)) {
             group.setVisible(true);
             for (int j = 0; j < group.getPreferenceCount(); j++) {
                 Preference child = group.getPreference(j);
                 if (child instanceof PreferenceGroup) {
-                    filterGroup((PreferenceGroup) child, "");
+                    restoreVisibility((PreferenceGroup) child);
                 } else {
-                    child.setVisible(true);
+                    Boolean childVisible = mOriginalVisibility.get(child);
+                    child.setVisible(childVisible == null || childVisible);
                 }
             }
             return;

--- a/src/main/java/com/archos/mediacenter/video/utils/VideoPreferencesFragment.java
+++ b/src/main/java/com/archos/mediacenter/video/utils/VideoPreferencesFragment.java
@@ -14,22 +14,30 @@
 package com.archos.mediacenter.video.utils;
 
 import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.graphics.Insets;
+import android.os.Build;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.View;
 import android.view.ViewGroup;
-
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
+import android.view.WindowInsets;
+import android.widget.EditText;
 
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceGroupAdapter;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.PreferenceViewHolder;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.archos.mediacenter.video.CustomApplication;
+import com.archos.mediacenter.video.R;
+
+import java.util.Locale;
 
 public class VideoPreferencesFragment extends PreferenceFragmentCompat {
 
@@ -44,11 +52,63 @@ public class VideoPreferencesFragment extends PreferenceFragmentCompat {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         // Adjust padding for edge-to-edge
-        ViewCompat.setOnApplyWindowInsetsListener(view, (v, insets) -> {
-            androidx.core.graphics.Insets systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-            v.setPadding(systemBarsInsets.left, systemBarsInsets.top, systemBarsInsets.right, systemBarsInsets.bottom);
-            return insets;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            view.setOnApplyWindowInsetsListener((v, insets) -> {
+                Insets systemBarsInsets = insets.getInsets(WindowInsets.Type.systemBars());
+                applySearchBoxInsets(view, systemBarsInsets.top);
+                v.setPadding(systemBarsInsets.left, 0, systemBarsInsets.right, systemBarsInsets.bottom);
+                return insets;
+            });
+        } else {
+            view.setOnApplyWindowInsetsListener((v, insets) -> {
+                applySearchBoxInsets(view, insets.getSystemWindowInsetTop());
+                v.setPadding(
+                        insets.getSystemWindowInsetLeft(),
+                        0,
+                        insets.getSystemWindowInsetRight(),
+                        insets.getSystemWindowInsetBottom()
+                );
+                return insets;
+            });
+        }
+        // The search box lives in the Activity layout (sibling of this fragment),
+        // so it can only be reached once the view is attached to the window.
+        view.post(() -> {
+            if (getActivity() == null) return;
+            EditText searchEdit = getActivity().findViewById(R.id.preferences_search);
+            if (searchEdit != null) {
+                searchEdit.addTextChangedListener(new TextWatcher() {
+                    @Override
+                    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                    }
+
+                    @Override
+                    public void onTextChanged(CharSequence s, int start, int before, int count) {
+                    }
+
+                    @Override
+                    public void afterTextChanged(Editable s) {
+                        filterPreferences(s == null ? "" : s.toString());
+                    }
+                });
+            }
         });
+    }
+
+    private void applySearchBoxInsets(View fragmentView, int statusBarTop) {
+        View root = fragmentView.getRootView();
+        if (root == null) return;
+        EditText search = root.findViewById(R.id.preferences_search);
+        if (search != null) {
+            float density = search.getResources().getDisplayMetrics().density;
+            int extraV = (int) (8 * density);
+            search.setPadding(
+                    (int) (12 * density),
+                    statusBarTop + extraV,
+                    (int) (12 * density),
+                    extraV
+            );
+        }
     }
 
     @Override
@@ -69,4 +129,69 @@ public class VideoPreferencesFragment extends PreferenceFragmentCompat {
         mPreferencesCommon.onSaveInstanceState(outState);
     }
 
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        mPreferencesCommon.onActivityResult(requestCode, resultCode, data);
+    }
+
+    private void filterPreferences(String query) {
+        PreferenceScreen screen = getPreferenceScreen();
+        if (screen == null) return;
+        filterGroup(screen, query == null ? "" : query.trim());
+    }
+
+    private void filterGroup(PreferenceGroup group, String q) {
+        if (q.isEmpty()) {
+            group.setVisible(true);
+            for (int j = 0; j < group.getPreferenceCount(); j++) {
+                Preference child = group.getPreference(j);
+                if (child instanceof PreferenceGroup) {
+                    filterGroup((PreferenceGroup) child, q);
+                } else {
+                    child.setVisible(true);
+                }
+            }
+            return;
+        }
+        if (matchesQuery(group, q)) {
+            group.setVisible(true);
+            for (int j = 0; j < group.getPreferenceCount(); j++) {
+                Preference child = group.getPreference(j);
+                if (child instanceof PreferenceGroup) {
+                    filterGroup((PreferenceGroup) child, "");
+                } else {
+                    child.setVisible(true);
+                }
+            }
+            return;
+        }
+        boolean anyVisible = false;
+        for (int j = 0; j < group.getPreferenceCount(); j++) {
+            Preference child = group.getPreference(j);
+            if (child instanceof PreferenceGroup) {
+                filterGroup((PreferenceGroup) child, q);
+                anyVisible |= child.isVisible();
+            } else {
+                boolean childVisible = matchesQuery(child, q);
+                child.setVisible(childVisible);
+                anyVisible |= childVisible;
+            }
+        }
+        group.setVisible(anyVisible);
+    }
+
+    private boolean matchesQuery(Preference preference, String q) {
+        return titleMatches(preference, q) || summaryMatches(preference, q);
+    }
+
+    private boolean titleMatches(Preference preference, String q) {
+        CharSequence title = preference.getTitle();
+        return title != null && title.toString().toLowerCase(Locale.ROOT).contains(q);
+    }
+
+    private boolean summaryMatches(Preference preference, String q) {
+        CharSequence summary = preference.getSummary();
+        return summary != null && summary.toString().toLowerCase(Locale.ROOT).contains(q);
+    }
 }

--- a/src/main/java/com/archos/mediacenter/video/utils/VideoPreferencesFragment.java
+++ b/src/main/java/com/archos/mediacenter/video/utils/VideoPreferencesFragment.java
@@ -191,9 +191,10 @@ public class VideoPreferencesFragment extends PreferenceFragmentCompat {
                 filterGroup((PreferenceGroup) child, q);
                 anyVisible |= child.isVisible();
             } else {
-                boolean childVisible = matchesQuery(child, q);
-                child.setVisible(childVisible);
-                anyVisible |= childVisible;
+                Boolean originalVisible = mOriginalVisibility.get(child);
+                boolean visible = matchesQuery(child, q) && (originalVisible == null || originalVisible);
+                child.setVisible(visible);
+                anyVisible |= visible;
             }
         }
         group.setVisible(anyVisible);


### PR DESCRIPTION
Adds two improvements to the video preferences screen:

1. **Video orientation preference** (`Video > Orientation`)
   - New `ListPreference` with Auto / Landscape (horizontal) / Portrait (vertical).
   - `PlayerActivity` now applies it on start via `setOrientationFromPreference()` instead of blindly calling `setLockRotation(mLockRotation)`, so portrait videos can be locked vertically on phones.

2. **Searchable settings screen**
   - New search box at the top of `VideoPreferencesActivity` (edge-to-edge aware: padded below the status bar).
   - Typing filters the visible preferences by title or summary, recursively over nested groups/subcategories (`filterGroup()`); clears to restore everything.

Fixes on the phone (Android 15 / edge-to-edge):
- search field was drawn under the status bar and untappable;
- typing in the settings search did nothing (the fragment looked up a sibling view too early; now attached via `view.post()`).

VIDEO: https://www.youtube.com/shorts/fwUNcZYiXb4