### PR TITLE
fix: fallback to default YouTube icon for unknown trailer services

### DIFF
--- a/src/main/java/com/archos/mediacenter/video/utils/TrailerServiceIconFactory.java
+++ b/src/main/java/com/archos/mediacenter/video/utils/TrailerServiceIconFactory.java
@@ -25,6 +25,6 @@ public class TrailerServiceIconFactory {
         if ("YouTube".equalsIgnoreCase(service)) {
             return R.drawable.youtube;
         }
-        return -1;
+        return R.drawable.youtube;
     }
 }


### PR DESCRIPTION
Currently, TrailerServiceIconFactory returned -1 when the service name didn't match "YouTube". Passing -1 to Context.getDrawable() would fail to resolve valid drawable resources and cause app crash. 

This updated getIconForService() will return R.drawable.youtube as a default fallback icon to avoid crash.